### PR TITLE
libboost libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ You need the following libraries:
 - libcurl
 - libstdc++
 - libgcrypt
-- Boost (Boost filesystem, program_options, regex, unit_test_framework and system are required)
+- Boost (Boost filesystem, program_options, regex, unit_test_framework and system are required.
+  libboost-all-dev should contain all of them)
 - expat
 
 There are also some optional dependencies:


### PR DESCRIPTION
it takes a while to find and install all boost libraries, especially the unit_test_framework. This hint has been a great help:
http://ubuntuforums.org/showthread.php?t=1725216#post_message_10662335