### PR TITLE
std::vector::erase is expensive; use std::list:erase instead

### DIFF
--- a/libgrive/src/base/State.cc
+++ b/libgrive/src/base/State.cc
@@ -172,9 +172,9 @@ std::size_t State::TryResolveEntry()
 	assert( !m_unresolved.empty() ) ;
 
 	std::size_t count = 0 ;
-	std::vector<Entry>& en = m_unresolved ;
-	
-	for ( std::vector<Entry>::iterator i = en.begin() ; i != en.end() ; )
+	std::list<Entry>& en = m_unresolved ;
+
+	for ( std::list<Entry>::iterator i = en.begin() ; i != en.end() ; )
 	{
 		if ( Update( *i ) )
 		{

--- a/libgrive/src/base/State.hh
+++ b/libgrive/src/base/State.hh
@@ -79,7 +79,7 @@ private :
 	Val					m_st ;
 	bool				m_force ;
 	
-	std::vector<Entry>	m_unresolved ;
+	std::list<Entry>	m_unresolved ;
 } ;
 
 } // end of namespace gr


### PR DESCRIPTION
erasing from a vector at random is very expensive. std::list however is made for that purpose!

found this using valgrind; a ridiculous amount of time was spent in vector::erase
ran valgrind again afterwards: list::erase is barely noticable