### PR TITLE
Ignores symlinks and processes other files, instead of crashing if th…

### DIFF
--- a/libgrive/src/base/Resource.cc
+++ b/libgrive/src/base/Resource.cc
@@ -246,7 +246,15 @@ void Resource::FromLocal( Val& state )
 	{
 		fs::path path = Path() ;
 		bool is_dir;
+
+		// If the file is a symlink or invalid filename, os::Stat will throw an exception,
+		// and m_state might become "unknown". So we will force m_state to be "sync" to ignore
+		// this file just before running os::Stat, and if os::Stat succeeds then we set m_state
+		// back to its original value.
+		State prevState = m_state;
+		m_state = sync; // Ignore this file
 		os::Stat( path, &m_ctime, NULL, &is_dir ) ;
+		m_state = prevState;    // Set it back to the actual state value, if it got a valid file.
 
 		m_name = path.filename().string() ;
 		m_kind = is_dir ? "folder" : "file";

--- a/libgrive/src/base/State.cc
+++ b/libgrive/src/base/State.cc
@@ -115,9 +115,20 @@ void State::FromLocal( const fs::path& p, Resource* folder, Val& tree )
 			Val& rec = tree.Item( fname );
 			if ( m_force )
 				rec.Del( "srv_time" );
-			c->FromLocal( rec ) ;
-			if ( c->IsFolder() )
-				FromLocal( *i, c, rec.Item( "tree" ) ) ;
+
+			try
+			{
+				// Get the filename
+				c->FromLocal( rec ) ;
+				if ( c->IsFolder() )
+					FromLocal( *i, c, rec.Item( "tree" ) ) ;
+			}
+			catch (std::exception &e)
+			{
+				// If we couldn't get a valid filename (eg: for a symlink), skip the file.
+				Log("Warning: File '%1%' is invalid or is a symlink, so will skip it.", path);
+				//Log(e.what());
+			}
 		}
 	}
 


### PR DESCRIPTION
grive2 was crashing if it saw a symlink pointing to an invalid file. With my code patch, it will just ignore that bad symlink and continue processing other valid files instead of crashing.