### PR TITLE
Fix man page to reflect fix #58

### DIFF
--- a/grive/doc/grive.1
+++ b/grive/doc/grive.1
@@ -48,7 +48,6 @@ Produces help message
 .TP
 \fB\-\-ignore\fR <perl_regexp>
 Ignore files with relative paths matching this Perl Regular Expression.
-Value is remembered for next runs.
 .TP
 \fB\-l\fR <filename>, \fB\-\-log\fR <filename>
 Write log output to
@@ -70,7 +69,7 @@ as the working copy root directory
 \fB\-s\fR <subdir>, \fB\-\-dir\fR <subdir>
 Sync a single
 .I <subdir>
-subdirectory. Internally converted to an ignore regexp, remembered for next runs.
+subdirectory. Internally converted to an ignore regexp.
 .TP
 \fB\-v\fR, \fB\-\-version\fR
 Displays program version


### PR DESCRIPTION
"Make ignore regexp non-persistent (fix #58)" should be reflected in the
man page.