### PR TITLE
also compile with cURL Version less than 7.32.0

### DIFF
--- a/libgrive/src/http/CurlAgent.cc
+++ b/libgrive/src/http/CurlAgent.cc
@@ -190,8 +190,10 @@ long CurlAgent::ExecCurl(
 	struct curl_slist *slist = SetHeader( m_pimpl->curl, hdr ) ;
 
 	curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-	curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, progress_callback);
-	curl_easy_setopt(curl, CURLOPT_XFERINFODATA, this);
+    #if LIBCURL_VERSION_NUM >= 0x072000
+  	  curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, progress_callback);
+	  curl_easy_setopt(curl, CURLOPT_XFERINFODATA, this);
+    #endif
 
 	CURLcode curl_code = ::curl_easy_perform(curl);
 


### PR DESCRIPTION
Refering to this issue: vitalif#116 the constants CURLOPT_XFERINFOFUNCTION and CURLOPT_XFERINFODATA are not defined on cURL versions prior to 7.32.0, so compilation will fail on older systems, for example Raspian on the Raspberry Pi.

With this patch compilation will pass. Only drawback is that cURL uses its own "xfer info" function.