### PR TITLE
Ubuntu ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ bgrive/bgrive
 grive/grive
 libgrive/btest
 *.cmake
+debian/debhelper-build-stamp
+debian/files
+debian/grive.debhelper.log
+debian/grive.substvars
+debian/grive/
+obj-x86_64-linux-gnu/

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: grive2
 Section: net
 Priority: optional
 Maintainer: Vitaliy Filippov <vitalif@mail.ru>
-Build-Depends: debhelper, cmake, pkg-config, zlib1g-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev, libstdc++-6-dev | libstdc++6-4.4-dev | libstdc++-4.9-dev | libstdc++-5-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-test-dev, libboost-regex-dev, libexpat1-dev, binutils-dev, libgcrypt-dev, libyajl-dev
+Build-Depends: debhelper, cmake, pkg-config, zlib1g-dev, libcurl4-gnutls-dev, libstdc++-6-dev | libstdc++6-4.4-dev | libstdc++-4.9-dev | libstdc++-5-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-test-dev, libboost-regex-dev, libexpat1-dev, binutils-dev, libgcrypt-dev, libyajl-dev
 Standards-Version: 3.9.6
 Homepage: https://yourcmc.ru/wiki/Grive2
 


### PR DESCRIPTION
Small fixes to build the deb package on ubuntu 16.10

The problem for the first commit was probably the same as in https://github.com/vitalif/grive2/issues/100