### PR TITLE
added 3 more dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ On a Debian/Ubuntu/Linux Mint machine just run the following command to install 
 these packages:
 
     sudo apt-get install git cmake build-essential libgcrypt11-dev libyajl-dev \
-        libboost-all-dev libcurl4-openssl-dev libexpat1-dev libcppunit-dev binutils-dev
+        libboost-all-dev libcurl4-openssl-dev libexpat1-dev libcppunit-dev binutils-dev \
+        debhelper zlib1g-dev dpkg-dev
 
 FreeBSD:
 


### PR DESCRIPTION
on linux mint 18.3 I also had to install "debhelper", "zlib1g-dev" & "dpkg-dev" to be able to run the dpkg-buildpackage command