### PR TITLE
Added libstdc++-7-dev in the Build-Depends for Ubuntu 17.10

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: grive2
 Section: net
 Priority: optional
 Maintainer: Vitaliy Filippov <vitalif@mail.ru>
-Build-Depends: debhelper, cmake, pkg-config, zlib1g-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev, libstdc++-6-dev | libstdc++6-4.4-dev | libstdc++-4.9-dev | libstdc++-5-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-test-dev, libboost-regex-dev, libexpat1-dev, binutils-dev, libgcrypt-dev, libyajl-dev
+Build-Depends: debhelper, cmake, pkg-config, zlib1g-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev, libstdc++-7-dev |libstdc++-6-dev | libstdc++6-4.4-dev | libstdc++-4.9-dev | libstdc++-5-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-test-dev, libboost-regex-dev, libexpat1-dev, binutils-dev, libgcrypt-dev, libyajl-dev
 Standards-Version: 3.9.6
 Homepage: https://yourcmc.ru/wiki/Grive2
 


### PR DESCRIPTION
Just a tiny change to create the deb package on Ubuntu 17.10