### PR TITLE
Fix uninitialized use of c2 variable in State::FromLocal

### DIFF
--- a/libgrive/src/base/State.cc
+++ b/libgrive/src/base/State.cc
@@ -140,7 +140,7 @@ void State::FromLocal( const fs::path& p, Resource* folder, Val& tree )
 		else
 		{
 			// Restore state of locally deleted files
-			Resource *c = folder->FindChild( i->first ), *c2 ;
+			Resource *c = folder->FindChild( i->first ), *c2 = c ;
 			if ( !c )
 			{
 				c2 = new Resource( i->first, i->second.Has( "tree" ) ? "folder" : "file" ) ;


### PR DESCRIPTION
Clangs complains that `c2` may be uses uninitialized in `State::FromLocal`. Indeed, if `folder->FindChild( i->first )` returns anything but `nullptr`, that's what would happen.

The code prior to dd77c998728cd0f72ddc5fc2a4f1cfa6c5f139c3 was using `c->FromDeleted( rec );` instead of `c2->FromDeleted( rec );` and the intention of the code change is to preserve the original `c` to be used as a condition for the `m_res.Insert` invocation.

The same method `State::FromLocal` initializes `c2` to `c` in the preceding loop. Just do the same thing for the second `c2`.