### PR TITLE
Link against specific Boost libraries, avoid using Boost_LIBRARIES

### DIFF
--- a/grive/CMakeLists.txt
+++ b/grive/CMakeLists.txt
@@ -17,7 +17,6 @@ add_executable( grive_executable
 )
 
 target_link_libraries( grive_executable
-	${Boost_LIBRARIES}
 	grive
 )
 

--- a/libgrive/CMakeLists.txt
+++ b/libgrive/CMakeLists.txt
@@ -83,7 +83,10 @@ target_link_libraries( grive
 	${YAJL_LIBRARIES}
 	${CURL_LIBRARIES}
 	${LIBGCRYPT_LIBRARIES}
-	${Boost_LIBRARIES}
+	${Boost_FILESYSTEM_LIBRARY}
+	${Boost_PROGRAM_OPTIONS_LIBRARY}
+	${Boost_REGEX_LIBRARY}
+	${Boost_SYSTEM_LIBRARY}
 	${IBERTY_LIBRARY}
 	${EXPAT_LIBRARY}
 	${OPT_LIBS}
@@ -126,7 +129,6 @@ IF ( CPPUNIT_FOUND )
 	target_link_libraries( unittest
 		grive
 		${CPPUNIT_LIBRARY}
-		${Boost_LIBRARIES}
 	)
         
 ENDIF ( CPPUNIT_FOUND )
@@ -139,7 +141,7 @@ add_executable( btest ${BTEST_SRC} )
 
 target_link_libraries( btest
 	grive
-	${Boost_LIBRARIES}
+	${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
 )
 
 if ( WIN32 )


### PR DESCRIPTION
grive should not be linked against the Boost unit test framework, only
btest needs it.

Don't specify Boost libraries for executables if libgrive uses those
libraries. CMake takes care of the dependencies.