### PR TITLE
Fix include patterns in .griveignore

### DIFF
--- a/libgrive/src/base/State.cc
+++ b/libgrive/src/base/State.cc
@@ -77,6 +77,7 @@ State::State( const fs::path& root, const Val& options  ) :
 
 	m_ign_changed = m_orig_ign != "" && m_orig_ign != m_ign;
 	m_ign_re = boost::regex( m_ign.empty() ? "^\\.(grive$|grive_state$|trash)" : ( m_ign+"|^\\.(grive|grive_state|trash)" ) );
+        Log( "Ignore file regexp: %1%", m_ign_re.str(), log::verbose );
 }
 
 State::~State()
@@ -358,7 +359,7 @@ bool State::ParseIgnoreFile( const char* buffer, int size )
 				if ( !inc )
 					exclude_re = exclude_re + ( exclude_re.size() > 0 ? "|" : "" ) + str;
 				else
-					include_re = include_re + ( include_re.size() > 0 ? "|" : "" ) + str;
+					include_re = include_re + ( include_re.size() > 0 ? "|" : "" ) + str + "\\Z";
 			}
 			prev = i+1;
 		}


### PR DESCRIPTION
Hi, this is an attempt at fixing include patterns in `.griveignore` following the discussion in bug #208.

Basically, the patch assures that include patterns are converted into lookahead patterns terminated by `\Z` in the regular expression used to sift the filenames.

In this way if you have an include pattern (e.g., `database`), this only matches `database` rather than matching *anything starting with `database`* as it is currently (and incorrectly) the case.

The patch also assures that the regular expression is printed when one asks for a verbose output.