### PR TITLE
Fix include patterns in .griveignore

### DIFF
--- a/libgrive/src/base/State.cc
+++ b/libgrive/src/base/State.cc
@@ -79,6 +79,7 @@ State::State( const fs::path& root, const Val& options  ) :
 
 	m_ign_changed = m_orig_ign != "" && m_orig_ign != m_ign;
 	m_ign_re = boost::regex( m_ign.empty() ? "^\\.(grive$|grive_state$|trash)" : ( m_ign+"|^\\.(grive$|grive_state$|trash)" ) );
+        Log( "Ignore file regexp: %1%", m_ign_re.str(), log::verbose );
 }
 
 State::~State()
@@ -388,7 +389,7 @@ bool State::ParseIgnoreFile( const char* buffer, int size )
 			for ( int j = 0; j < (int)parts.size(); j++ )
 			{
 				cur = cur.size() > 0 ? cur + "/" + parts[j] : "^" + parts[j];
-				str = ( str.size() > 0 ? str + "|" + cur : cur ) + ( j < (int)parts.size()-1 ? "$" : "(/|$)" );
+				str = ( str.size() > 0 ? str + "|" + cur : cur ) + "$";
 			}
 			include_re = include_re + ( include_re.size() > 0 ? "|" : "" ) + str;
 		}


### PR DESCRIPTION
Hi, this is an attempt at fixing include patterns in `.griveignore` following the discussion in bug #208.

Basically, the patch assures that include patterns are converted into lookahead patterns terminated by `$` in the regular expression used to sift the filenames.

In this way if you have an include pattern (e.g., `database`), this only matches `database` rather than `database` and *anything* below it (as it is currently and incorrectly the case).

If you want to include `database` and anything below, then you should have `!database**` in your `.griveignore`.

The patch also assures that the regular expression is printed when one asks for a verbose output, so that some debugging is possible.