### PR TITLE
Escape folder when calling sync from change listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ Prepare a Google Drive folder in your $HOME directory with `grive -a`.
 
 ```bash
 # 'google-drive' is the name of your Google Drive folder in your $HOME directory
-systemctl --user enable grive-timer@google-drive.timer
-systemctl --user start grive-timer@google-drive.timer
-systemctl --user enable grive-changes@google-drive.service
-systemctl --user start grive-changes@google-drive.service
+systemctl --user enable grive-timer@$(systemd-escape google-drive).timer
+systemctl --user start grive-timer@$(systemd-escape google-drive).timer
+systemctl --user enable grive-changes@$(systemd-escape google-drive).service
+systemctl --user start grive-changes@$(systemd-escape google-drive).service
 ```
 
 You can enable and start these two units for multiple folders in your `$HOME`

--- a/systemd/grive-sync.sh
+++ b/systemd/grive-sync.sh
@@ -107,7 +107,7 @@ listen_directory() {
 	while true #run indefinitely
 	do 
 		# Use a different call to not need to change exit into return
-		inotifywait -q -r -e modify,attrib,close_write,move,create,delete --exclude ".grive_state|.grive" "${_directory}" > /dev/null 2>&1 && ${SCRIPT} sync "${_directory}"
+		inotifywait -q -r -e modify,attrib,close_write,move,create,delete --exclude ".grive_state|.grive" "${_directory}" > /dev/null 2>&1 && ${SCRIPT} sync $(systemd-escape "${_directory}")
 		#echo ${SCRIPT} "${_directory}"
 	done
 


### PR DESCRIPTION
The old version would pass in an unescaped directory, which then got unescaped by the sync call. 

In some cases it worked but resulted in foldername would not matched reality (example: google-drive -> google/drive) and error out when checking if that folder exists.

Fixes: #231