### PR TITLE
Revert "Exclude symlinks from sync"

### DIFF
--- a/systemd/grive-sync.sh
+++ b/systemd/grive-sync.sh
@@ -79,12 +79,6 @@ sync_directory() {
 	while [[ "${TIME_AT_START}" -lt "${TIME_AT_END}" ]]; do
 	    echo "Syncing "${_directory}"..." 
 	    TIME_AT_START="$(stat -c %Y "$LOCKFILE")"
-	    # exclude symlinks from sync
-	    cat "${_directory}"/.griveignore 2>/dev/null | sed '/#LINKS-EDIT_BEFORE_THIS$/,$d' > /tmp/.griveignore.base
-	    cp /tmp/.griveignore.base "${_directory}"/.griveignore
-	    rm /tmp/.griveignore.base
-	    echo "#LINKS-EDIT_BEFORE_THIS" >> "${_directory}"/.griveignore
-	    ( cd "${_directory}" && find . -type l | sed 's/^.\///g'; ) >> "${_directory}"/.griveignore
 	    grive -p "${_directory}" 2>&1 | grep -v -E "^Reading local directories$|^Reading remote server file list$|^Synchronizing files$|^Finished!$"
 	    TIME_AT_END="$(stat -c %Y "$LOCKFILE")"
 	    echo "Sync of "${_directory}" done." 


### PR DESCRIPTION
This reverts commit b47dd70f35ff74362c7094a55123a1be2618e5be.

As discovered in #241 the griveignore handling in the sync script could trigger a infinite loop between the timer unit (running a sync and changing the griveignore file at the start) and the changes unit (reacting to the griveignore change and retriggering the sync).

Reverting for now, as requested by the original author @psfloyd in https://github.com/vitalif/grive2/issues/241#issuecomment-443855068

Closes: #241