### PR TITLE
macOS fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_program(
 )
 if ( HAVE_SYSTEMD )
 	add_subdirectory( systemd )
-endif( NOT HAVE_SYSTEMD )
+endif( HAVE_SYSTEMD )
 
 add_subdirectory( libgrive )
 add_subdirectory( grive )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,19 @@ set( GRIVE_VERSION "0.5.1-dev" )
 # common compile options
 add_definitions( -DVERSION="${GRIVE_VERSION}" )
 add_definitions( -D_FILE_OFFSET_BITS=64 -std=c++0x )
+if ( APPLE )
+	add_definitions( -Doff64_t=off_t )
+endif ( APPLE )
 
-add_subdirectory( systemd )
+find_program(
+	HAVE_SYSTEMD systemd
+	PATHS /lib/systemd /usr/lib/systemd
+	NO_DEFAULT_PATH
+)
+if ( HAVE_SYSTEMD )
+	add_subdirectory( systemd )
+endif( NOT HAVE_SYSTEMD )
+
 add_subdirectory( libgrive )
 add_subdirectory( grive )
-	
+

--- a/libgrive/src/base/Feed.cc
+++ b/libgrive/src/base/Feed.cc
@@ -30,6 +30,10 @@ Feed::Feed( const std::string &url ):
 {
 }
 
+Feed::~Feed()
+{
+}
+
 Feed::iterator Feed::begin() const
 {
 	return m_entries.begin() ;

--- a/libgrive/src/base/Feed.hh
+++ b/libgrive/src/base/Feed.hh
@@ -41,6 +41,7 @@ public :
 public :
 	Feed( const std::string& url );
 	virtual bool GetNext( http::Agent *http ) = 0 ;
+    virtual ~Feed() = 0 ;
 	iterator begin() const ;
 	iterator end() const ;
 

--- a/libgrive/src/base/Feed.hh
+++ b/libgrive/src/base/Feed.hh
@@ -41,7 +41,7 @@ public :
 public :
 	Feed( const std::string& url );
 	virtual bool GetNext( http::Agent *http ) = 0 ;
-    virtual ~Feed() = 0 ;
+	virtual ~Feed() = 0 ;
 	iterator begin() const ;
 	iterator end() const ;
 

--- a/libgrive/src/drive2/Feed2.cc
+++ b/libgrive/src/drive2/Feed2.cc
@@ -36,6 +36,10 @@ Feed2::Feed2( const std::string& url ):
 {
 }
 
+Feed2::~Feed2()
+{
+}
+
 bool Feed2::GetNext( http::Agent *http )
 {
 	if ( m_next.empty() )

--- a/libgrive/src/drive2/Feed2.hh
+++ b/libgrive/src/drive2/Feed2.hh
@@ -31,7 +31,7 @@ class Feed2: public Feed
 {
 public :
 	Feed2( const std::string& url ) ;
-    ~Feed2() ;
+	~Feed2() ;
 	bool GetNext( http::Agent *http ) ;
 } ;
 

--- a/libgrive/src/drive2/Feed2.hh
+++ b/libgrive/src/drive2/Feed2.hh
@@ -31,6 +31,7 @@ class Feed2: public Feed
 {
 public :
 	Feed2( const std::string& url ) ;
+    ~Feed2() ;
 	bool GetNext( http::Agent *http ) ;
 } ;
 


### PR DESCRIPTION
This makes Grive build on macOS (tested with MacPorts).

There's no systemd on macOS, so this makes CMake look for the systemd binary and installs the systemd units conditionally. This is a portable check for `systemd` but really only applies to Linux.

I can provide launchctl service files if desired.