### PR TITLE
Extends support application id and secret support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 2.8)
 include(GNUInstallDirs)
 
 # Grive version. remember to update it for every new release!
-set( GRIVE_VERSION "0.5.2-dev" )
+set( GRIVE_VERSION "0.5.2-dev" CACHE STRING "Grive version" )
+message(WARNING "Version to build: ${GRIVE_VERSION}")
 
 # common compile options
 add_definitions( -DVERSION="${GRIVE_VERSION}" )
@@ -12,4 +13,3 @@ add_definitions( -D_FILE_OFFSET_BITS=64 -std=c++0x )
 add_subdirectory( systemd )
 add_subdirectory( libgrive )
 add_subdirectory( grive )
-	

--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ Grive uses cmake to build. Basic install sequence is
     make -j4
     sudo make install
 
+Alternativly you can define your own client_id and client_secret during build
+
+    mkdir build
+    cd build
+    cmake .. "-DAPP_ID:STRING=<client_id>" "-DAPP_SECRET:STRING=<client_secret>"
+    make -j4
+    sudo make install
+
 ## Version History
 
 ### Grive2 v0.5.2-dev

--- a/grive/CMakeLists.txt
+++ b/grive/CMakeLists.txt
@@ -20,6 +20,17 @@ target_link_libraries( grive_executable
 	grive
 )
 
+set(DEFAULT_APP_ID "615557989097-i93d4d1ojpen0m0dso18ldr6orjkidgf.apps.googleusercontent.com")
+set(DEFAULT_APP_SECRET "xiM8Apu_WuRRdheNelJcNtOD")
+set(APP_ID ${DEFAULT_APP_ID} CACHE STRING "Application Id")
+set(APP_SECRET ${DEFAULT_APP_SECRET} CACHE STRING "Application Secret")
+
+target_compile_definitions ( grive_executable
+	PRIVATE
+		-DAPP_ID="${APP_ID}"
+		-DAPP_SECRET="${APP_SECRET}"
+)
+
 set_target_properties( grive_executable
 	PROPERTIES OUTPUT_NAME grive
 )

--- a/libgrive/src/util/Config.cc
+++ b/libgrive/src/util/Config.cc
@@ -38,6 +38,10 @@ const std::string	default_root_folder = ".";
 
 Config::Config( const po::variables_map& vm )
 {
+	if ( vm.count( "id" ) > 0 )
+		m_cmd.Add( "id",	Val( vm["id"].as<std::string>() ) ) ;
+	if ( vm.count( "secret" ) > 0 )
+		m_cmd.Add( "secret",	Val( vm["secret"].as<std::string>() ) ) ;
 	m_cmd.Add( "new-rev",	Val(vm.count("new-rev") > 0) ) ;
 	m_cmd.Add( "force",		Val(vm.count("force") > 0 ) ) ;
 	m_cmd.Add( "path",		Val(vm.count("path") > 0


### PR DESCRIPTION
With this pull request grive2 will have more advanced support of the custom client id and secret.

- cmake: projects supports custom id's during cmake config (see README)
- client id and secret always saved in `.grive` config file after `grive -a`
-  new CLI option added `grive -a --print-url` which will return generated url for token request

Small changes:
- cmake: GRIVE_VERSION is cached and can be overwritten during cmake config