### PR TITLE
Fix Fedora (and RHEL) suggested dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ these packages:
 
 Fedora:
 
-    sudo dnf install git cmake libgcrypt-devel gcc-c++ libstdc++ yajl-devel boost libcurl-devel expat-devel binutils zlib
+    sudo dnf install git cmake libgcrypt-devel gcc-c++ libstdc++ yajl-devel boost-devel libcurl-devel expat-devel binutils zlib
 
 
 FreeBSD:


### PR DESCRIPTION
We need boost-devel to compile.