### PR TITLE
Add instruction for replacing the OAuth2 client

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,31 @@ your folder. They need to be added explicitly to your Google Drive: go to the
 Google Drive website, right click on the file or folder and chose 'Add to My
 Drive'.
 
+### Different OAuth2 client to workaround over quota issues
+
+The default OAuth2 client supplied with grive is sometimes over quota and grive
+will then fail to sync. You can supply your own OAuth2 client credentials by
+following these steps:
+
+1. Go to https://console.developers.google.com/apis/api/drive.googleapis.com
+2. Chose a project (you might need to create one first)
+3. Go to https://console.developers.google.com/apis/library/drive.googleapis.com and
+   "Enable" the Google Drive APIs
+4. Create new Credentials on the folloing screen(s)
+5. In the "Find out what credentials you need" dialog, choose:
+   - Which API are you using: "Google Drive API"
+   - Where will you be calling the API from: "Other UI (...CLI...)"
+   - What data will you be accessing: "User Data"
+6. In the next steps create a client id (name doesn't matter) and
+   setup the consent screen (defaults are ok, no need for any URLs)
+7. The needed "Client ID" and "Client Secret" are either in the shown download
+   or can later found by clicking on the created credential on
+   https://console.developers.google.com/apis/credentials/
+8. When you applying grive in an existing Google Drive folder, you must first delete
+   the old `.grive` configuration file.
+9. Call `grive -a --id <client_id> --secret <client_secret>` and follow the steps
+   to authenticate the OAuth2 client to allow it to access your drive folder.
+
 ## Installation
 
 For the detailed instructions, see http://yourcmc.ru/wiki/Grive2#Installation


### PR DESCRIPTION
This is cherry-pick from pull request https://github.com/vitalif/grive2/pull/242
Additionally added a step about removing of the old configuration file.