### PR TITLE
Support compilation with binutils >= 2.33.1 on Debian.

### DIFF
--- a/libgrive/src/bfd/SymbolInfo.cc
+++ b/libgrive/src/bfd/SymbolInfo.cc
@@ -49,9 +49,9 @@ SymbolInfo::SymbolInfo( )
 	m_impl->m_bfd		= 0 ;
 	m_impl->m_symbols	= 0 ;
 	m_impl->m_symbol_count	= 0 ;
-	
+
 	bfd_init( ) ;
-	
+
 	// opening itself
 	bfd *b = bfd_openr( "/proc/self/exe", 0 ) ;
 	if ( b == NULL )
@@ -60,13 +60,13 @@ SymbolInfo::SymbolInfo( )
 		          << bfd_errmsg( bfd_get_error() ) << std::endl ;
 		return ;
 	}
-	
+
 	if ( bfd_check_format( b, bfd_archive ) )
 	{
 		bfd_close( b ) ;
 		return ;
 	}
-	
+
 	char **matching ;
 	if ( !bfd_check_format_matches( b, bfd_object, &matching ) )
 	{
@@ -78,7 +78,7 @@ SymbolInfo::SymbolInfo( )
 			std::cerr << bfd_get_filename( b ) << ": Matching formats: " ;
 			for ( char **p = matching ; *p != 0 ; p++ )
 				std::cerr << " " << *p ;
-			
+
 			std::cerr << std::endl ;
 			std::free( matching ) ;
 		}
@@ -107,7 +107,7 @@ struct SymbolInfo::BacktraceInfo
 	const char			*m_func_name ;
 	unsigned int		m_lineno ;
 	unsigned int		m_is_found ;
-	
+
 	static void Callback( bfd *abfd, asection *section, void* addr ) ;
 } ;
 
@@ -117,17 +117,24 @@ void SymbolInfo::BacktraceInfo::Callback( bfd *abfd, asection *section,
 	BacktraceInfo *info = (BacktraceInfo *)data ;
 	if ((section->flags & SEC_ALLOC) == 0)
 		return ;
-	
-	bfd_vma vma = bfd_get_section_vma(abfd, section);
-	
+
+	// bfd_get_section_vma works up to 7b1cfbcf1a27951fb1b3a212995075dd6fdf985b,
+	// removed in 7c13bc8c91abf291f0206b6608b31955c5ea70d8 (binutils 2.33.1 or so)
+	// so it's substituted by its implementation to avoid checking for binutils
+	// version (which at least on Debian SID it's not that easy because the
+	// version.h is not included with the official package)
+	bfd_vma vma = section->vma;
+
 	unsigned long address = (unsigned long)(info->m_addr);
 	if ( address < vma )
 		return;
-	
-	bfd_size_type size = bfd_section_size(abfd, section);
+
+	// bfd_section_size changed between the two objects described above,
+	// same rationale applies
+	bfd_size_type size = section->size;
 	if ( address > (vma + size))
 		return ;
-	
+
 	const SymbolInfo *pthis	= info->m_pthis ;
 	info->m_is_found	=  bfd_find_nearest_line( abfd, section,
 	                                              pthis->m_impl->m_symbols,
@@ -149,7 +156,7 @@ void SymbolInfo::PrintTrace( void *addr, std::ostream& os, std::size_t idx )
 	{
 		this, addr, 0, 0, 0, false
 	} ;
-	
+
 	Dl_info sym ;
 	bfd_map_over_sections( m_impl->m_bfd,
 							&SymbolInfo::BacktraceInfo::Callback,
@@ -165,7 +172,7 @@ if ( btinfo.m_is_found )
 			filename.erase( pos, std::strlen( SRC_DIR ) ) ;
 #endif
 		os << "#"  << idx << " " << addr << " "
-			<< filename << ":" << btinfo.m_lineno 
+			<< filename << ":" << btinfo.m_lineno
 			<< " "
 			<< (btinfo.m_func_name != 0 ? Demangle(btinfo.m_func_name) : "" )
 			<< std::endl ;


### PR DESCRIPTION
SymbolInfo.cc does not compile on Debian SID (2.33.50.20200107-1)

bfd_get_section_vma macro was removed.
bfd_section_size changed signature.

See inline comment for details.