### PR TITLE
fix systemd-escape hyphen usage

### DIFF
--- a/systemd/grive-sync.sh
+++ b/systemd/grive-sync.sh
@@ -15,7 +15,7 @@ cd ~
 
 ### ARGUMENT PARSING ###
 SCRIPT="${0}"
-DIRECTORY=$(systemd-escape --unescape "$2")
+DIRECTORY=$(systemd-escape --unescape -- "$2")
 
 if [[ -z "$DIRECTORY" ]] || [[ ! -d "$DIRECTORY" ]] ; then
 	echo "Need a directory name in the current users home directory as second argument. Aborting."


### PR DESCRIPTION
Minor fix to add `--` to the call to `systemd-escape --unescape` for the systemd script. With the system I most recently installed the grive service on, its `systemd-escape` replaces backslashes with hyphens and was trying to interpret the directory as more argument flags.

e.g. in /var/log/syslog:
```
Mar  3 02:20:54 nn grive-sync.sh[7945]: systemd-escape: invalid option -- 'n'
Mar  3 02:20:54 nn grive-sync.sh[7945]: Need a directory name in the current users home directory as second argument. Aborting.
```

It should be noted I ignored the fact that the directory should be in $HOME (my directory is /mnt/drive) so after escaping would become "-mnt-drive", hence the need for adding `--` to support paths from root. This change is pretty innocuous and shouldn't interfere with the instructions as they are currently written.