### PR TITLE
fixed: CMAKE_INSTALL_FULL_LIBDIR -> CMAKE_INSTALL_FULL_LIBEXECDIR

### DIFF
--- a/systemd/CMakeLists.txt
+++ b/systemd/CMakeLists.txt
@@ -23,5 +23,5 @@ install(
   PROGRAMS
     grive-sync.sh
   DESTINATION
-    ${CMAKE_INSTALL_FULL_LIBDIR}/grive
+    ${CMAKE_INSTALL_FULL_LIBEXECDIR}/grive
 )


### PR DESCRIPTION
Because, It must equal GRIVE_SYNC_SH_BINARY and actual grive-sync.sh path.
I patched my gentoo overlay ebuild.
[added: grive: libexec patch · ncaq/ncaq-overlay@ed3354f](https://github.com/ncaq/ncaq-overlay/commit/ed3354fbb704b78cfc5a1779036ce444fde40933)