### PR TITLE
Google installed app loopback redirect OAuth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Grive2 0.5.2-dev](#grive2-052-dev)
+  - [Usage](#usage)
+    - [Exclude specific files and folders from sync: .griveignore](#exclude-specific-files-and-folders-from-sync-griveignore)
+    - [Scheduled syncs and syncs on file change events](#scheduled-syncs-and-syncs-on-file-change-events)
+    - [Shared files](#shared-files)
+    - [Different OAuth2 client to workaround over quota and google approval issues](#different-oauth2-client-to-workaround-over-quota-and-google-approval-issues)
+  - [Installation](#installation)
+    - [Install dependencies](#install-dependencies)
+    - [Build Debian packages](#build-debian-packages)
+    - [Manual build](#manual-build)
+  - [Version History](#version-history)
+    - [Grive2 v0.5.2-dev](#grive2-v052-dev)
+    - [Grive2 v0.5.1](#grive2-v051)
+    - [Grive2 v0.5](#grive2-v05)
+    - [Grive2 v0.4.2](#grive2-v042)
+    - [Grive2 v0.4.1](#grive2-v041)
+    - [Grive2 v0.4.0](#grive2-v040)
+    - [Grive v0.3](#grive-v03)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Grive2 0.5.2-dev
 
 13 Nov 2019, Vitaliy Filippov
@@ -154,7 +179,7 @@ You need the following libraries:
 - libgcrypt
 - Boost (Boost filesystem, program_options, regex, unit_test_framework and system are required)
 - expat
-- libcpprest-dev
+- [libcpprest-dev](https://github.com/Microsoft/cpprestsdk)
 
 There are also some optional dependencies:
 - CppUnit (for unit tests)

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ grive -a
 
 A URL should be printed. Go to the link. You will need to login to your Google
 account if you haven't done so. After granting the permission to Grive, the
-browser will show you an authenication code. Copy-and-paste that to the
-standard input of Grive.
+authorization code will be forwarded to the Grive application and you will be
+redirected to a localhost web page confirming the authorization.
 
-If everything works fine, Grive will create .grive and .grive_state files in your
-current directory. It will also start downloading files from your Google Drive to
-your current directory.
+If everything works fine, Grive will create .grive and .grive\_state files in
+your current directory. It will also start downloading files from your Google
+Drive to your current directory.
 
 To resync the direcory, run `grive` in the folder.
 
@@ -154,6 +154,7 @@ You need the following libraries:
 - libgcrypt
 - Boost (Boost filesystem, program_options, regex, unit_test_framework and system are required)
 - expat
+- libcpprest-dev
 
 There are also some optional dependencies:
 - CppUnit (for unit tests)
@@ -165,16 +166,17 @@ these packages:
 
     sudo apt-get install git cmake build-essential libgcrypt20-dev libyajl-dev \
         libboost-all-dev libcurl4-openssl-dev libexpat1-dev libcppunit-dev binutils-dev \
-        debhelper zlib1g-dev dpkg-dev pkg-config
+        debhelper zlib1g-dev dpkg-dev pkg-config libcpprest-dev
 
 Fedora:
 
-    sudo dnf install git cmake libgcrypt-devel gcc-c++ libstdc++ yajl-devel boost-devel libcurl-devel expat-devel binutils zlib
+    sudo dnf install git cmake libgcrypt-devel gcc-c++ libstdc++ yajl-devel boost-devel libcurl-devel expat-devel binutils zlib cpprest-devel
 
 
 FreeBSD:
 
     pkg install git cmake boost-libs yajl libgcrypt pkgconf cppunit libbfd
+    cpprestsdk
 
 ### Build Debian packages
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: grive2
 Section: net
 Priority: optional
 Maintainer: Vitaliy Filippov <vitalif@mail.ru>
-Build-Depends: debhelper, cmake, pkg-config, zlib1g-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-test-dev, libboost-regex-dev, libexpat1-dev, libgcrypt-dev, libyajl-dev
+Build-Depends: debhelper, cmake, pkg-config, zlib1g-dev, libcurl4-openssl-dev | libcurl4-gnutls-dev, libboost-filesystem-dev, libboost-program-options-dev, libboost-test-dev, libboost-regex-dev, libexpat1-dev, libgcrypt-dev, libyajl-dev, libcpprest-dev
 Standards-Version: 3.9.6
 Homepage: https://yourcmc.ru/wiki/Grive2
 

--- a/grive/CMakeLists.txt
+++ b/grive/CMakeLists.txt
@@ -1,6 +1,8 @@
 project( grive )
 
 find_package(Boost COMPONENTS program_options REQUIRED)
+find_package(cpprestsdk REQUIRED)
+find_package(OpenSSL REQUIRED)
 
 include_directories(
 	${grive_SOURCE_DIR}/../libgrive/src
@@ -18,6 +20,8 @@ add_executable( grive_executable
 
 target_link_libraries( grive_executable
 	grive
+	OpenSSL::Crypto
+	cpprestsdk::cpprest
 )
 
 set(DEFAULT_APP_ID "615557989097-i93d4d1ojpen0m0dso18ldr6orjkidgf.apps.googleusercontent.com")

--- a/grive/src/main.cc
+++ b/grive/src/main.cc
@@ -52,7 +52,6 @@
 
 const std::string default_id            = APP_ID ;
 const std::string default_secret        = APP_SECRET ;
-const std::string default_redirect_uri  = "http://localhost:9898" ;
 
 using namespace gr ;
 namespace po = boost::program_options;
@@ -110,7 +109,7 @@ void InitLog( const po::variables_map& vm )
 }
 
 // AuthCode reads an authorization code from the "code" query parameter passed
-// via client-side redirect to the redirect_uri specified in uri
+// via client-side redirect to the redirect uri specified in uri
 std::string AuthCode( std::string uri )
 {
 	// Set up an HTTP listener that is waiting for Google
@@ -249,9 +248,7 @@ int Main( int argc, char **argv )
 		std::string secret = vm.count( "secret" ) > 0
                         ? vm["secret"].as<std::string>()
                         : default_secret ;
-		std::string redirect_uri = vm.count( "redirect-uri" ) > 0
-			? vm["redirect-uri"].as<std::string>()
-			: default_redirect_uri ;
+		std::string redirect_uri = config.Get("redirect-uri").Str();
 
 		OAuth2 token( http.get(), id, secret, redirect_uri ) ;
 		
@@ -274,7 +271,7 @@ int Main( int argc, char **argv )
 		config.Set( "id", Val( id ) ) ;
 		config.Set( "secret", Val( secret ) ) ;
 		config.Set( "refresh_token", Val( token.RefreshToken() ) ) ;
-		config.Set( "redirect_uri", Val( redirect_uri ) ) ;
+		config.Set( "redirect-uri", Val( redirect_uri ) ) ;
 		config.Save() ;
 	}
 	
@@ -287,7 +284,7 @@ int Main( int argc, char **argv )
 		refresh_token = config.Get("refresh_token").Str() ;
 		id = config.Get("id").Str() ;
 		secret = config.Get("secret").Str() ;
-		redirect_uri = config.Get("redirect_uri").Str() ;
+		redirect_uri = config.Get("redirect-uri").Str() ;
 	}
 	catch ( Exception& e )
 	{

--- a/grive/src/main.cc
+++ b/grive/src/main.cc
@@ -249,11 +249,11 @@ int Main( int argc, char **argv )
 		std::string secret = vm.count( "secret" ) > 0
                         ? vm["secret"].as<std::string>()
                         : default_secret ;
-		std::string uri = vm.count( "redirect-uri" ) > 0
+		std::string redirect_uri = vm.count( "redirect-uri" ) > 0
 			? vm["redirect-uri"].as<std::string>()
 			: default_redirect_uri ;
 
-		OAuth2 token( http.get(), id, secret ) ;
+		OAuth2 token( http.get(), id, secret, redirect_uri ) ;
 		
 		if ( vm.count("print-url") )
 		{
@@ -267,24 +267,27 @@ int Main( int argc, char **argv )
 			<< token.MakeAuthURL()
 			<< std::endl ;
 
-		std::string code = AuthCode(uri);
+		std::string code = AuthCode(redirect_uri);
 		token.Auth( code ) ;
 		
 		// save to config
 		config.Set( "id", Val( id ) ) ;
 		config.Set( "secret", Val( secret ) ) ;
 		config.Set( "refresh_token", Val( token.RefreshToken() ) ) ;
+		config.Set( "redirect_uri", Val( redirect_uri ) ) ;
 		config.Save() ;
 	}
 	
 	std::string refresh_token ;
 	std::string id ;
 	std::string secret ;
+	std::string redirect_uri ;
 	try
 	{
 		refresh_token = config.Get("refresh_token").Str() ;
 		id = config.Get("id").Str() ;
 		secret = config.Get("secret").Str() ;
+		redirect_uri = config.Get("redirect_uri").Str() ;
 	}
 	catch ( Exception& e )
 	{
@@ -296,7 +299,7 @@ int Main( int argc, char **argv )
 		return -1;
 	}
 	
-	OAuth2 token( http.get(), refresh_token, id, secret ) ;
+	OAuth2 token( http.get(), refresh_token, id, secret, redirect_uri ) ;
 	AuthAgent agent( token, http.get() ) ;
 	v2::Syncer2 syncer( &agent );
 

--- a/libgrive/src/protocol/OAuth2.cc
+++ b/libgrive/src/protocol/OAuth2.cc
@@ -35,12 +35,14 @@ const std::string token_url		= "https://accounts.google.com/o/oauth2/token" ;
 OAuth2::OAuth2(
 	http::Agent* agent,
 	const std::string& refresh_code,
-	const std::string&	client_id,
-	const std::string&	client_secret ) :
+	const std::string& client_id,
+	const std::string& client_secret,
+	const std::string& redirect_uri ) :
 	m_refresh( refresh_code ),
 	m_agent( agent ),
 	m_client_id( client_id ),
-	m_client_secret( client_secret )
+	m_client_secret( client_secret ),
+	m_redirect_uri ( redirect_uri )
 {
 	Refresh( ) ;
 }
@@ -48,10 +50,12 @@ OAuth2::OAuth2(
 OAuth2::OAuth2(
 	http::Agent* agent,
 	const std::string&	client_id,
-	const std::string&	client_secret ) :
+	const std::string&	client_secret,
+	const std::string&	redirect_uri ) :
 	m_agent( agent ),
 	m_client_id( client_id ),
-	m_client_secret( client_secret )
+	m_client_secret( client_secret ),
+	m_redirect_uri( redirect_uri )
 {
 }
 
@@ -61,7 +65,7 @@ void OAuth2::Auth( const std::string&	auth_code )
 		"code="				+ auth_code +
 		"&client_id="		+ m_client_id +
 		"&client_secret="	+ m_client_secret +
-		"&redirect_uri="	+ "urn:ietf:wg:oauth:2.0:oob" +
+		"&redirect_uri="	+ m_redirect_uri +
 		"&grant_type=authorization_code" ;
 
 	http::ValResponse  resp ;
@@ -85,7 +89,7 @@ std::string OAuth2::MakeAuthURL()
 {
 	return "https://accounts.google.com/o/oauth2/auth"
 		"?scope=" + m_agent->Escape( "https://www.googleapis.com/auth/drive" ) +
-		"&redirect_uri=urn:ietf:wg:oauth:2.0:oob"
+		"&redirect_uri=" + m_redirect_uri +
 		"&response_type=code"
 		"&client_id=" + m_client_id ;
 }

--- a/libgrive/src/protocol/OAuth2.hh
+++ b/libgrive/src/protocol/OAuth2.hh
@@ -35,12 +35,14 @@ public :
 	OAuth2(
 		http::Agent* agent,
 		const std::string&	client_id,
-		const std::string&	client_secret ) ;
+		const std::string&	client_secret,
+		const std::string&	redirect_uri ) ;
 	OAuth2(
 		http::Agent* agent,
 		const std::string&	refresh_code,
 		const std::string&	client_id,
-		const std::string&	client_secret ) ;
+		const std::string&	client_secret,
+		const std::string&	redirect_uri ) ;
 
 	std::string Str() const ;
 
@@ -62,6 +64,7 @@ private :
 	
 	const std::string	m_client_id ;
 	const std::string	m_client_secret ;
+	const std::string	m_redirect_uri ;
 } ;
 
 } // end of namespace

--- a/libgrive/src/util/Config.cc
+++ b/libgrive/src/util/Config.cc
@@ -47,6 +47,8 @@ Config::Config( const po::variables_map& vm )
 	m_cmd.Add( "path",		Val(vm.count("path") > 0
 		? vm["path"].as<std::string>()
 		: default_root_folder ) ) ;
+	if ( vm.count( "redirect_uri" ) > 0 )
+		m_cmd.Add( "redirect_uri",	Val( vm["redirect_uri"].as<std::string>() ) ) ;
 	m_cmd.Add( "dir",		Val(vm.count("dir") > 0
 		? vm["dir"].as<std::string>()
 		: "" ) ) ;

--- a/libgrive/src/util/Config.cc
+++ b/libgrive/src/util/Config.cc
@@ -32,9 +32,10 @@ namespace po = boost::program_options;
 
 namespace gr {
 
-const std::string	default_filename	= ".grive";
-const char			*env_name			= "GR_CONFIG";
-const std::string	default_root_folder = ".";
+const char *env_name                   = "GR_CONFIG";
+const std::string default_filename     = ".grive";
+const std::string default_root_folder  = ".";
+const std::string default_redirect_uri = "http://localhost:9898" ;
 
 Config::Config( const po::variables_map& vm )
 {
@@ -47,8 +48,6 @@ Config::Config( const po::variables_map& vm )
 	m_cmd.Add( "path",		Val(vm.count("path") > 0
 		? vm["path"].as<std::string>()
 		: default_root_folder ) ) ;
-	if ( vm.count( "redirect_uri" ) > 0 )
-		m_cmd.Add( "redirect_uri",	Val( vm["redirect_uri"].as<std::string>() ) ) ;
 	m_cmd.Add( "dir",		Val(vm.count("dir") > 0
 		? vm["dir"].as<std::string>()
 		: "" ) ) ;
@@ -60,6 +59,14 @@ Config::Config( const po::variables_map& vm )
 	
 	m_path	= GetPath( fs::path(m_cmd["path"].Str()) ) ;
 	m_file	= Read( ) ;
+
+	if ( vm.count( "redirect-uri" ) > 0 ) {
+		m_cmd.Add( "redirect-uri", Val( vm["redirect-uri"].as<std::string>() ) );
+	} else if (m_file.Has( "redirect-uri" )) {
+		;
+	} else {
+		m_cmd.Add( "redirect-uri", Val( default_redirect_uri ) );
+	}
 }
 
 fs::path Config::GetPath( const fs::path& root_path )
@@ -86,7 +93,7 @@ void Config::Save( )
 
 void Config::Set( const std::string& key, const Val& value )
 {
-	m_file.Add( key, value ) ;
+	m_file.Set( key, value ) ;
 }
 
 Val Config::Get( const std::string& key ) const

--- a/package/fedora16/grive.spec
+++ b/package/fedora16/grive.spec
@@ -36,6 +36,7 @@ BuildRequires:  expat-devel
 BuildRequires:  openssl-devel
 BuildRequires:  boost-devel
 BuildRequires:  binutils-devel
+BuildRequires:  cpprest-devel
 
 %description
 The purpose of this project is to provide an independent implementation


### PR DESCRIPTION
As per [Making Google OAuth interactions safer by using more secure OAuth flows](https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html), Google is deprecating the Out-Of-Band OAuth flow for installed desktop apps that `grive2` currently uses on October 3, 2022. I'm actually not 100% if this includes requests for new access tokens given an existing, valid refresh token.

Following the [Out-Of-Band (OOB) flow Migration Guide](https://developers.google.com/identity/protocols/oauth2/resources/oob-migration), this PR attempts to migrate the app to use the [Loopback IP address](https://developers.google.com/identity/protocols/oauth2/native-app#redirect-uri_loopback) flow. It does this by spinning up a small HTTP server on `localhost` to accept the client-side redirect from the Google user consent flow.

Key CR considerations:
* I added a dependency on [cpprestsdk](https://github.com/Microsoft/cpprestsdk) to simplify the process of creating an HTTP listener on `localhost`. Not sure if that's kosher, so lmk if there's a better way to do this! In particular, I don't think this particular dependency is currently packaged on Alpine Linux which I saw the included Dockerfile using.
* I really don't know much about either C++ or CMake, but AFAICT I did need to explicitly [link OpenSSL](https://github.com/bclarkx2/grive2/blob/master/grive/CMakeLists.txt#L23). I think that's OK since it's a runtime dynamic link (I think lol), but again lmk if that's going to be a problem.
* I didn't update the version from `0.5.2-dev` since I wasn't sure if you'd prefer to bundle updates into releases, but I am happy to increment this in this PR if preferred!