### PR TITLE
Fix for out of bounds write in musl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7 as build
+FROM alpine:3.19 as build
 
 RUN apk add make cmake g++ libgcrypt-dev yajl-dev yajl \
 	boost-dev curl-dev expat-dev cppunit-dev binutils-dev \


### PR DESCRIPTION
https://security.snyk.io/vuln/SNYK-ALPINE37-MUSL-458286

Alpine 3.7.3 is no longer supported by the Alpine team. Alpine 3.19 contains a version of musl that is not vulnerable to this particular vulnerability.